### PR TITLE
fix: Add Altinn require to folder scripts for Bruno V3

### DIFF
--- a/Altinn Platform/AccessManagement/folder.bru
+++ b/Altinn Platform/AccessManagement/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "tokenType": "enterprise",
       "orgNo": "991825827",

--- a/Altinn Platform/Authorization (external)/folder.bru
+++ b/Altinn Platform/Authorization (external)/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "orgNo": "991825827", // Digdir
       //"orgNo": "889640782", // NAV

--- a/Altinn Platform/Events/folder.bru
+++ b/Altinn Platform/Events/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "tokenType": "enterprise",
       "orgNo": "991825827", // Digdir

--- a/Altinn Platform/Events/subscriptions/subscription for person/folder.bru
+++ b/Altinn Platform/Events/subscriptions/subscription for person/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "tokenType": "person",
       "scopes": "altinn:events.subscribe",

--- a/Altinn Platform/Register/folder.bru
+++ b/Altinn Platform/Register/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "tokenType": "enterprise",
       "orgNo": "991825827",

--- a/Altinn Platform/ResourceRegistry/folder.bru
+++ b/Altinn Platform/ResourceRegistry/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
      // "orgNo": "713431400", // Digdir yt01
      "orgNo": "991825827", // Digdir

--- a/Altinn Platform/Storage/Applications/folder.bru
+++ b/Altinn Platform/Storage/Applications/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "tokenType": "platform",
       "app": "studio.designer"

--- a/Altinn Platform/Storage/Instances/folder.bru
+++ b/Altinn Platform/Storage/Instances/folder.bru
@@ -8,7 +8,9 @@ auth {
 }
 
 script:pre-request {
-  (new Altinn(pm)).Authenticate({
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
+  await (new Altinn(req)).Authenticate({
       "tokenType": "enterprise",
       //"orgNo": "991825827", // Digdir/TTD
       //"orgNo": "974760983",

--- a/Altinn Platform/Storage/folder.bru
+++ b/Altinn Platform/Storage/folder.bru
@@ -8,6 +8,8 @@ auth {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "tokenType": "enterprise",
       "orgNo": "991825827",

--- a/Dialogporten/EndUser/folder.bru
+++ b/Dialogporten/EndUser/folder.bru
@@ -3,7 +3,7 @@ meta {
 }
 
 script:pre-request {
-  const altinn = new Altinn(req);
+  const Altinn = require(bru.cwd() + '/pre_request.js');
   
   await (new Altinn(req)).Authenticate({
       /* */

--- a/Dialogporten/ServiceOwner/folder.bru
+++ b/Dialogporten/ServiceOwner/folder.bru
@@ -4,6 +4,8 @@ meta {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "orgNo": "991825827", // Digdir
       // "orgNo": "974761076", // Skatteetaten

--- a/Dialogporten/Testing/folder.bru
+++ b/Dialogporten/Testing/folder.bru
@@ -4,6 +4,8 @@ meta {
 }
 
 script:pre-request {
+  const Altinn = require(bru.cwd() + '/pre_request.js');
+  
   await (new Altinn(req)).Authenticate({
       "orgNo": "991825827", // Digdir
       //"orgNo": "974761076", // Skatteetaten

--- a/collection.bru
+++ b/collection.bru
@@ -7,10 +7,6 @@ auth {
   mode: none
 }
 
-script:pre-request {
-  const Altinn = require('./pre_request.js');
-}
-
 docs {
   Altinn Request collection for Dialogporten
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Bruno V3 isolates script scopes between levels, so each folder now
imports Altinn directly using bru.cwd().

## Related Issue(s)
- #9 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
